### PR TITLE
feature: treat wiki files like markdown files

### DIFF
--- a/autoload/autolink.vim
+++ b/autoload/autolink.vim
@@ -160,14 +160,14 @@ endfunction
 " Main entry functions and default bindings.
 
 function! autolink#DefComplete()
-    if (&filetype == "markdown" || &filetype == "mkd")
+    if (&filetype == "markdown" || &filetype == "mkd" || &filetype == "wiki")
         call s:markdown_complete()
     elseif &filetype == "rst"
         call s:rest_complete()
     endif
 endfunction
 function! autolink#DefCreate()
-    if (&filetype == "markdown" || &filetype == "mkd")
+    if (&filetype == "markdown" || &filetype == "mkd" || &filetype == "wiki")
         call s:markdown_create()
     elseif &filetype == "rst"
         call s:rest_create()
@@ -192,7 +192,7 @@ function! autolink#CombinedBrowser()
     execute "normal! `q"
 endfunction
 function! autolink#Search()
-    if (&filetype == "markdown" || &filetype == "mkd")
+    if (&filetype == "markdown" || &filetype == "mkd" || &filetype == "wiki")
         let key = s:markdown_get_key()
     elseif &filetype == "rst"
         let key = s:rest_get_key()

--- a/plugin/autolink.vim
+++ b/plugin/autolink.vim
@@ -10,5 +10,5 @@ function! AutoLinkDefaultBindings()
 endfunction
 augroup AutoLink
     autocmd!
-    autocmd FileType markdown,rst :call AutoLinkDefaultBindings()
+    autocmd FileType markdown,wiki,rst :call AutoLinkDefaultBindings()
 augroup END


### PR DESCRIPTION
Wherever the code asks if the filetype is markdown, it now also returns `true` if the filetype is wiki. The mappings are also created for wiki files (in addition to markdown and rst).